### PR TITLE
Enabling grpc output service

### DIFF
--- a/helm/falco-app/values.yaml
+++ b/helm/falco-app/values.yaml
@@ -9,6 +9,8 @@ falco:
   falco:
     grpc:
       enabled: true
+    grpc_output:
+      enabled: true
 
 falco-exporter:
   podSecurityPolicy:


### PR DESCRIPTION
Forgot to enable grpc outputs service. Without this, looks like no events would actually be exposed. 

```
Then, remember to enable the services you need, otherwise the gRPC server won't expose anything, for the outputs use:


# gRPC output service.
# By default it is off.
# By enabling this all the output events will be kept in memory until you read them with a gRPC client.
# Make sure to have a consumer for them or leave this disabled.
```

https://falco.org/docs/grpc/#configuration