### PR TITLE
Fix Changelog and update Readme to re-release v0.2.0 after failed CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2021-12-15
-
 ### Changed
 
 - Update to upstream charts: Falco 1.16.2/0.30.0, exporter 0.6.3/0.6.0, sidekick 0.4.4/2.24.0.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 Giant Swarm offers a [falco](https://falco.org/) App which can be installed in workload clusters.
 Here we define the falco chart with its templates and default configuration.
 
-**What is this app?**
-**Why did we add it?**
-**Who can use it?**
+Falco is a host-based intrusion detection system which watches and checks Linux syscalls against a predefined list of rules. Anomalous activity (as defined by the rules) triggers a Falco event, which can be used to alert responders or take automated remediation actions.
 
 ## Installing
 
@@ -19,9 +17,13 @@ There are 3 ways to install this app onto a workload cluster.
 
 ## Configuring
 
+**Note: There are currently known compatibility issues when using the Falco kernel module with Flatcar kernel version 5.10.77-flatcar and later. The ebpf driver must be used instead (see the sample `user-values-configmap.yaml` below).**
+
 ### values.yaml
+
 **This is an example of a values file you could upload using our web interface.**
-```
+
+```yaml
 # values.yaml
 
 global:
@@ -30,8 +32,6 @@ global:
 falco:
   podSecurityPolicy:
     create: true
-  serviceAccount:
-    name: falco-user
   falco:
     grpc:
       enabled: true
@@ -48,8 +48,6 @@ falco:
 falco-exporter:
   podSecurityPolicy:
     create: true
-  serviceAccount:
-    name: falco-user
 
 falcosidekick:
 
@@ -71,37 +69,22 @@ Please see the below page for configurable values.
 [Falco sidekick Configuration](helm/falco-app/charts/falcosidekick#configuration)
 
 ### Sample App CR and ConfigMap for the management cluster
+
 If you have access to the Kubernetes API on the management cluster, you could create
 the App CR and ConfigMap directly.
 
-Here is an example that would install the app to
-workload cluster `abc12`:
+You can provide additional configuration via a ConfigMap or the web interface.
 
-```
-# appCR.yaml
-
-```
-
-```
+```yaml
 # user-values-configmap.yaml
-
+# To use the ebpf driver instead of the Falco kernel module:
+falco:
+  ebpf:
+    enabled: "true"
 
 ```
 
 See our [full reference page on how to configure applications](https://docs.giantswarm.io/app-platform/app-configuration/) for more details.
-
-## Compatibility
-
-This app has been tested to work with the following workload cluster release versions:
-
-*
-
-## Limitations
-
-Some apps have restrictions on how they can be deployed.
-Not following these limitations will most likely result in a broken deployment.
-
-*
 
 ## Credit
 


### PR DESCRIPTION
Release failed after https://github.com/giantswarm/falco-app/pull/57 because the automation was too old. I've fixed it now, so will re-trigger the release, including a new compatibility note.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
