### PR TITLE
Fix changelog to re-release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2021-12-17
-
 ### Changed
 
 - Update to upstream charts: Falco 1.16.2/0.30.0, exporter 0.6.3/0.6.0, sidekick 0.4.4/2.24.0.
@@ -37,8 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Push `falco-app` to provider collections (except KVM) when tagged.
 - Use Giant Swarm-managed images.
 
-[Unreleased]: https://github.com/giantswarm/falco-app/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/giantswarm/falco-app/compare/v0.1.2...v0.2.0
+[Unreleased]: https://github.com/giantswarm/falco-app/compare/v0.1.2...HEAD
 [0.1.2]: https://github.com/giantswarm/falco-app/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/giantswarm/falco-app/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/giantswarm/falco-app/releases/tag/v0.1.0


### PR DESCRIPTION
Had to turn off squash merging to make the subtree update work, forgot to use squash merge again when merging the release branch, so the automation failed

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
