### PR TITLE
Use EBPF driver by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Use `ebpf` driver instead of kernel module by default.
+
 ## [0.3.1] - 2022-03-10
 
 ### Changed

--- a/helm/falco-app/values.yaml
+++ b/helm/falco-app/values.yaml
@@ -5,6 +5,8 @@ falco:
   podSecurityPolicy:
     create: true
   priorityClassName: giantswarm-critical
+  ebpf:
+    enabled: true
   falco:
     grpc:
       enabled: true


### PR DESCRIPTION
Using the kernel module driver remains problematic on newer Flatcar versions. As preview CAPI releases based on these newer kernels are now available to customers, this PR changes our Falco app to use the ebpf driver by default so Falco can run smoothly in preview environments.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

**Important:** After this PR is tested and approved, ensure you "Squash and Merge" _unless you are updating a subtree_. The release automation in use on this repository relies on squashing, but git subtrees will be lost if squashed. This repo allows both, so you may need to change the merge type when merging.
