### PR TITLE
Enabling falco audit plugin

### DIFF
--- a/helm/falco-app/values.yaml
+++ b/helm/falco-app/values.yaml
@@ -5,6 +5,15 @@ verticalPodAutoscaler:
   enabled: false
 
 falco:
+  services:
+    #Service where the k8s-api can push the auditlogs to. Settings shown below are default, but added to this file.
+    - name: k8saudit-webhook
+      type: NodePort
+      ports:
+        - port: 9765
+          nodePort: 30007
+          protocol: TCP
+
   image:
     registry: docker.io
     repository: giantswarm/falco
@@ -23,6 +32,20 @@ falco:
       enabled: true
     grpc_output:
       enabled: true
+    plugins:
+    #Putting plugins in this file because we might have to tweak them in the future.
+      - name: k8saudit
+        library_path: libk8saudit.so
+        init_config: # Still have to take a look whether we need to change these, yes or no.
+        #   maxEventSize: 262144
+        #   webhookMaxBatchSize: 12582912
+           sslCertificate: /etc/falco/falco.pem
+        open_params: "https://:9765/k8s-audit"
+        #Options are [A] We mount api-servers audit log file and read those [B] open a service endpoint which should be an auditsink.
+      - name: json
+        library_path: libjson.so
+        init_config: ""
+    load_plugins: [k8saudit, json]
   serviceAccount:
     # We set the service account name only so that we can use it for attaching a PSP.
     name: "falco"

--- a/helm/falco-app/values.yaml
+++ b/helm/falco-app/values.yaml
@@ -5,15 +5,6 @@ verticalPodAutoscaler:
   enabled: false
 
 falco:
-#  services:
-#    # Service where the k8s-api can push the auditlogs to. Settings shown below are default, but added to this file.
-#    - name: k8saudit-webhook
-#      type: NodePort
-#      ports:
-#        - port: 9765
-#          nodePort: 30007
-#          protocol: TCP
-
   image:
     registry: docker.io
     repository: giantswarm/falco
@@ -32,25 +23,28 @@ falco:
       enabled: true
     grpc_output:
       enabled: true
+    rules_file:
+    # adding the rule file list to override the default, because the default does not include plugin rules.
+      - /etc/falco/falco_rules.yaml
+      - /etc/falco/falco_rules.local.yaml
+      - /etc/falco/rules.d
+      - /etc/falco/k8s_audit_rules.yaml
     plugins:
-    # Putting plugins in this file because we might have to tweak them in the future.
       - name: k8saudit
         library_path: libk8saudit.so
         init_config:
-        # Still have to take a look whether we need to change these, yes or no.
-        #   maxEventSize: 262144
-        #   webhookMaxBatchSize: 12582912
-        #  sslCertificate: /etc/falco/falco.pem
         open_params: "/host/audit.log"
-        #  Options are [A] We mount api-servers audit log file and read those [B] open a service endpoint which should be an auditsink.
+        #  Other option is opening a service and add Falco to the k8s_audit sinks.
       - name: json
         library_path: libjson.so
         init_config: ""
     load_plugins: [k8saudit, json]
+    # The syscall "plugin"/functionality is enabled be default.
   serviceAccount:
     # We set the service account name only so that we can use it for attaching a PSP.
     name: "falco"
   mounts:
+    # Mounts the k8s_audit log file if present (only on api servers)
     volumes:
     - name: auditfile
       hostPath:

--- a/helm/falco-app/values.yaml
+++ b/helm/falco-app/values.yaml
@@ -33,7 +33,7 @@ falco:
       - name: k8saudit
         library_path: libk8saudit.so
         init_config:
-        open_params: "/host/audit.log"
+        open_params: "/host/apiserver/"
         #  Other option is opening a service and add Falco to the k8s_audit sinks.
       - name: json
         library_path: libjson.so
@@ -48,9 +48,9 @@ falco:
     volumes:
     - name: auditfile
       hostPath:
-        path: /var/log/apiserver/audit.log
+        path: /var/log/apiserver
     volumeMounts:
-    - mountPath: /host/audit.log
+    - mountPath: /host/apiserver
       name: auditfile
       readOnly: true
 

--- a/helm/falco-app/values.yaml
+++ b/helm/falco-app/values.yaml
@@ -6,7 +6,7 @@ verticalPodAutoscaler:
 
 falco:
   services:
-    #Service where the k8s-api can push the auditlogs to. Settings shown below are default, but added to this file.
+    # Service where the k8s-api can push the auditlogs to. Settings shown below are default, but added to this file.
     - name: k8saudit-webhook
       type: NodePort
       ports:
@@ -33,15 +33,16 @@ falco:
     grpc_output:
       enabled: true
     plugins:
-    #Putting plugins in this file because we might have to tweak them in the future.
+    # Putting plugins in this file because we might have to tweak them in the future.
       - name: k8saudit
         library_path: libk8saudit.so
-        init_config: # Still have to take a look whether we need to change these, yes or no.
+        init_config:
+        # Still have to take a look whether we need to change these, yes or no.
         #   maxEventSize: 262144
         #   webhookMaxBatchSize: 12582912
-           sslCertificate: /etc/falco/falco.pem
+          sslCertificate: /etc/falco/falco.pem
         open_params: "https://:9765/k8s-audit"
-        #Options are [A] We mount api-servers audit log file and read those [B] open a service endpoint which should be an auditsink.
+        # Options are [A] We mount api-servers audit log file and read those [B] open a service endpoint which should be an auditsink.
       - name: json
         library_path: libjson.so
         init_config: ""

--- a/helm/falco-app/values.yaml
+++ b/helm/falco-app/values.yaml
@@ -5,14 +5,14 @@ verticalPodAutoscaler:
   enabled: false
 
 falco:
-  services:
-    # Service where the k8s-api can push the auditlogs to. Settings shown below are default, but added to this file.
-    - name: k8saudit-webhook
-      type: NodePort
-      ports:
-        - port: 9765
-          nodePort: 30007
-          protocol: TCP
+#  services:
+#    # Service where the k8s-api can push the auditlogs to. Settings shown below are default, but added to this file.
+#    - name: k8saudit-webhook
+#      type: NodePort
+#      ports:
+#        - port: 9765
+#          nodePort: 30007
+#          protocol: TCP
 
   image:
     registry: docker.io
@@ -40,9 +40,9 @@ falco:
         # Still have to take a look whether we need to change these, yes or no.
         #   maxEventSize: 262144
         #   webhookMaxBatchSize: 12582912
-          sslCertificate: /etc/falco/falco.pem
-        open_params: "https://:9765/k8s-audit"
-        # Options are [A] We mount api-servers audit log file and read those [B] open a service endpoint which should be an auditsink.
+        #  sslCertificate: /etc/falco/falco.pem
+        open_params: "/host/audit.log"
+        #  Options are [A] We mount api-servers audit log file and read those [B] open a service endpoint which should be an auditsink.
       - name: json
         library_path: libjson.so
         init_config: ""
@@ -50,6 +50,16 @@ falco:
   serviceAccount:
     # We set the service account name only so that we can use it for attaching a PSP.
     name: "falco"
+  mounts:
+    volumes:
+    - name: auditfile
+      hostPath:
+        path: /var/log/apiserver/audit.log
+    volumeMounts:
+    - mountPath: /host/audit.log
+      name: auditfile
+      readOnly: true
+
 
 falco-exporter:
   image:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21911

This PR enables the Falco k8saudit-plugin and configures it so that it mounts the auditfile into the pod on apiservers for parsing through the falco engine. 

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

**Important:** After this PR is tested and approved, ensure you "Squash and Merge" _unless you are updating a subtree_. The release automation in use on this repository relies on squashing, but git subtrees will be lost if squashed. This repo allows both, so you may need to change the merge type when merging.
