### PR TITLE
Change registry to registry.k8s.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed the default `PolicyException` namespace to `giantswarm`.
 - Replace deprecated toleration `node-role.kubernetes.io/master` with `node-role.kubernetes.io/control-plane` on `falco` and `falco-exporter` Daemonsets.
+- Changed deprecated registry `k8s.gcr.io` to `registry.k8s.io`.
 
 ## [0.5.1] - 2023-03-28
 

--- a/helm/falco/charts/falco/rules/falco_rules.yaml
+++ b/helm/falco/charts/falco/rules/falco_rules.yaml
@@ -1858,14 +1858,18 @@
     gke.gcr.io/netd-amd64,
     gke.gcr.io/watcher-daemonset,
     gcr.io/google-containers/prometheus-to-sd,
-    k8s.gcr.io/ip-masq-agent-amd64,
-    k8s.gcr.io/kube-proxy,
-    k8s.gcr.io/prometheus-to-sd,
+    registry.k8s.io/ip-masq-agent-amd64,
+    registry.k8s.io/kube-proxy,
+    registry.k8s.io/prometheus-to-sd,
+    registry.k8s.io/ip-masq-agent-amd64,
+    registry.k8s.io/kube-proxy,
+    registry.k8s.io/prometheus-to-sd,
     public.ecr.aws/falcosecurity/falco,
     quay.io/calico/node,
     sysdig/sysdig,
     sematext_images,
-    k8s.gcr.io/dns/k8s-dns-node-cache
+    registry.k8s.io/dns/k8s-dns-node-cache,
+    registry.k8s.io/dns/k8s-dns-node-cache
     ]
 
 - macro: falco_privileged_containers
@@ -2410,7 +2414,8 @@
      public.ecr.aws/falcosecurity/falco, velero/velero,
      quay.io/jetstack/cert-manager-cainjector, weaveworks/kured,
      quay.io/prometheus-operator/prometheus-operator,
-     k8s.gcr.io/ingress-nginx/kube-webhook-certgen, quay.io/spotahome/redis-operator,
+     registry.k8s.io/ingress-nginx/kube-webhook-certgen,
+     registry.k8s.io/ingress-nginx/kube-webhook-certgen, quay.io/spotahome/redis-operator,
      registry.opensource.zalan.do/acid/postgres-operator, registry.opensource.zalan.do/acid/postgres-operator-ui,
      rabbitmqoperator/cluster-operator,
      falcosecurity/falco-no-driver, docker.io/falcosecurity/falco-no-driver,
@@ -2471,7 +2476,7 @@
 - macro: pkg_mgmt_in_kube_proxy
   condition: >
     proc.cmdline startswith "update-alternat"
-    and container.image.repository = "k8s.gcr.io/kube-proxy"
+    and container.image.repository = "registry.k8s.io/kube-proxy"
 
 - rule: Launch Package Management Process in Container
   desc: Package management process ran inside container
@@ -2889,8 +2894,8 @@
 
 - list: user_known_k8s_ns_kube_system_images
   items: [
-      k8s.gcr.io/fluentd-gcp-scaler,
-      k8s.gcr.io/node-problem-detector/node-problem-detector
+      registry.k8s.io/fluentd-gcp-scaler,
+      registry.k8s.io/node-problem-detector/node-problem-detector
   ]
 
 - list: user_known_k8s_images
@@ -2899,7 +2904,7 @@
   ]
 
 # Whitelist for known docker client binaries run inside container
-# - k8s.gcr.io/fluentd-gcp-scaler in GCP/GKE
+# - registry.k8s.io/fluentd-gcp-scaler in GCP/GKE
 - macro: user_known_k8s_client_container
   condition: >
     (k8s.ns.name="kube-system" and container.image.repository in (user_known_k8s_ns_kube_system_images)) or container.image.repository in (user_known_k8s_images)

--- a/helm/falco/charts/falco/rules/k8s_audit_rules.yaml
+++ b/helm/falco/charts/falco/rules/k8s_audit_rules.yaml
@@ -188,8 +188,8 @@
     gke.gcr.io/gke-metadata-server,
     gke.gcr.io/kube-proxy,
     gke.gcr.io/netd-amd64,
-    k8s.gcr.io/ip-masq-agent-amd64
-    k8s.gcr.io/prometheus-to-sd,
+    registry.k8s.io/ip-masq-agent-amd64
+    registry.k8s.io/prometheus-to-sd,
     ]
 
 # Corresponds to K8s CIS Benchmark 1.7.4
@@ -333,17 +333,17 @@
     gke.gcr.io/addon-resizer,
     gke.gcr.io/heapster,
     gke.gcr.io/gke-metadata-server,
-    k8s.gcr.io/ip-masq-agent-amd64,
-    k8s.gcr.io/kube-apiserver,
+    registry.k8s.io/ip-masq-agent-amd64,
+    registry.k8s.io/kube-apiserver,
     gke.gcr.io/kube-proxy,
     gke.gcr.io/netd-amd64,
     gke.gcr.io/watcher-daemonset,
-    k8s.gcr.io/addon-resizer
-    k8s.gcr.io/prometheus-to-sd,
-    k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64,
-    k8s.gcr.io/k8s-dns-kube-dns-amd64,
-    k8s.gcr.io/k8s-dns-sidecar-amd64,
-    k8s.gcr.io/metrics-server-amd64,
+    registry.k8s.io/addon-resizer
+    registry.k8s.io/prometheus-to-sd,
+    registry.k8s.io/k8s-dns-dnsmasq-nanny-amd64,
+    registry.k8s.io/k8s-dns-kube-dns-amd64,
+    registry.k8s.io/k8s-dns-sidecar-amd64,
+    registry.k8s.io/metrics-server-amd64,
     kope/kube-apiserver-healthcheck,
     k8s_image_list
     ]


### PR DESCRIPTION
No need to merge it for now but just for awareness.
At some point we might need to shift away from `k8s.gcr.io` because it won't be served anymore.

Feel free to close the PR or change it :slight_smile:

Related issue: https://github.com/giantswarm/roadmap/issues/2534


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.

**Important:** After this PR is tested and approved, ensure you "Squash and Merge" _unless you are updating a subtree_. The release automation in use on this repository relies on squashing, but git subtrees will be lost if squashed. This repo allows both, so you may need to change the merge type when merging.