### PR TITLE
allow egress to coredns in cilium network policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow egress to Coredns in Cilium network policy.
+
 ## [0.6.2] - 2023-08-07
 
 ### Added

--- a/helm/falco/templates/falco-ciliumnetworkpolicy.yaml
+++ b/helm/falco/templates/falco-ciliumnetworkpolicy.yaml
@@ -14,6 +14,11 @@ spec:
     - toEntities:
         - kube-apiserver
         - world
+    - toEntities:
+        - cluster
+        toPorts:
+          - ports:
+            - port: "1053"
   ingress:
     - fromEntities:
         - kube-apiserver


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/27838

falco & falco exporter pods fail to start because falco can't connect to `falcosecurity.github.io`.

### Checklist

- [x] Update changelog in CHANGELOG.md.
