### PR TITLE
Fix Cilium Network Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix Cilium Network Policy identation.
+- Fix Cilium Network Policy indentation.
 
 ## [0.6.3] - 2023-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Cilium Network Policy identation.
+
 ## [0.6.3] - 2023-08-22
 
 ### Fixed

--- a/helm/falco/templates/falco-ciliumnetworkpolicy.yaml
+++ b/helm/falco/templates/falco-ciliumnetworkpolicy.yaml
@@ -21,6 +21,6 @@ spec:
           - port: "1053"
   ingress:
     - fromEntities:
-      - kube-apiserver
-      - cluster
+        - kube-apiserver
+        - cluster
 {{- end }}

--- a/helm/falco/templates/falco-ciliumnetworkpolicy.yaml
+++ b/helm/falco/templates/falco-ciliumnetworkpolicy.yaml
@@ -16,11 +16,11 @@ spec:
         - world
     - toEntities:
         - cluster
-        toPorts:
-          - ports:
-            - port: "1053"
+      toPorts:
+        - ports:
+          - port: "1053"
   ingress:
     - fromEntities:
-        - kube-apiserver
-        - cluster
+      - kube-apiserver
+      - cluster
 {{- end }}


### PR DESCRIPTION
- Fix Cilium NetworkPolicy
- Update Changelog

There was an error with the indentation:

```
status:
  appVersion: 0.35.1
  release:
    lastDeployed: "2023-08-07T17:56:09Z"
    reason: 'YAML parse error on falco/templates/falco-ciliumnetworkpolicy.yaml: error
      converting YAML to JSON: yaml: line 26: did not find expected ''-'' indicator'
    status: unknown-error
  version: 0.6.2
```