### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.7.1] - 2023-12-14
 
 ### Changed
@@ -82,7 +86,7 @@ For more information, please check the falco [rules page](https://github.com/fal
 
 ### Changed
 
-- set `falcoctl` image to be taken from our own registry. 
+- set `falcoctl` image to be taken from our own registry.
 
 ## [0.6.0] - 2023-08-01
 

--- a/helm/falco/charts/falco-exporter/values.yaml
+++ b/helm/falco/charts/falco-exporter/values.yaml
@@ -37,7 +37,7 @@ healthChecks:
     periodSeconds: 15
 
 image:
-  registry: gsoci.azurecr.io
+  registry: docker.io
   repository: falcosecurity/falco-exporter
   tag: 0.8.3
   pullPolicy: IfNotPresent

--- a/helm/falco/charts/falco-exporter/values.yaml
+++ b/helm/falco/charts/falco-exporter/values.yaml
@@ -37,7 +37,7 @@ healthChecks:
     periodSeconds: 15
 
 image:
-  registry: docker.io
+  registry: gsoci.azurecr.io
   repository: falcosecurity/falco-exporter
   tag: 0.8.3
   pullPolicy: IfNotPresent
@@ -71,8 +71,7 @@ podSecurityPolicy:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # fsGroup: 2000
 
 daemonset:
@@ -90,15 +89,14 @@ daemonset:
 securityContext:
   capabilities:
     drop:
-    - ALL
+      - ALL
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   privileged: false
   seccompProfile:
     type: RuntimeDefault
 
-resources:
-  {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/helm/falco/charts/falco/values.yaml
+++ b/helm/falco/charts/falco/values.yaml
@@ -8,7 +8,7 @@ image:
   # -- The image pull policy.
   pullPolicy: IfNotPresent
   # -- The image registry to pull from.
-  registry: docker.io
+  registry: gsoci.azurecr.io
   # -- The image repository to pull from
   repository: falcosecurity/falco-no-driver
   # -- The image tag to pull. Overrides the image tag whose default is the chart appVersion.
@@ -211,7 +211,7 @@ driver:
         # -- The image pull policy.
         pullPolicy: IfNotPresent
         # -- The image registry to pull from.
-        registry: docker.io
+        registry: gsoci.azurecr.io
         # -- The image repository to pull from.
         repository: falcosecurity/falco-driver-loader
         #  -- Overrides the image tag whose default is the chart appVersion.
@@ -314,8 +314,7 @@ certs:
     # -- CA certificate used by gRPC, webserver and AuditSink validation.
     crt: ""
 # -- Third party rules enabled for Falco. More info on the dedicated section in README.md file.
-customRules:
-  {}
+customRules: {}
   # Although Falco comes with a nice default rule set for detecting weird
   # behavior in containers, our users are going to customize the run-time
   # security rule sets or policies for the specific container images and
@@ -347,7 +346,7 @@ falcoctl:
     # -- The image pull policy.
     pullPolicy: IfNotPresent
     # -- The image registry to pull from.
-    registry: docker.io
+    registry: gsoci.azurecr.io
     # -- The image repository to pull from.
     repository: falcosecurity/falcoctl
     # -- The image tag to pull.
@@ -391,8 +390,8 @@ falcoctl:
     # -- List of indexes that falcoctl downloads and uses to locate and download artiafcts. For more info see:
     # https://github.com/falcosecurity/falcoctl/blob/main/proposals/20220916-rules-and-plugin-distribution.md#index-file-overview
     indexes:
-    - name: falcosecurity
-      url: https://falcosecurity.github.io/falcoctl/index.yaml
+      - name: falcosecurity
+        url: https://falcosecurity.github.io/falcoctl/index.yaml
     # -- Configuration used by the artifact commands.
     artifact:
       # -- List of artifact types that falcoctl will handle. If the configured refs resolves to an artifact whose type is not contained

--- a/helm/falco/charts/falco/values.yaml
+++ b/helm/falco/charts/falco/values.yaml
@@ -8,7 +8,7 @@ image:
   # -- The image pull policy.
   pullPolicy: IfNotPresent
   # -- The image registry to pull from.
-  registry: gsoci.azurecr.io
+  registry: docker.io
   # -- The image repository to pull from
   repository: falcosecurity/falco-no-driver
   # -- The image tag to pull. Overrides the image tag whose default is the chart appVersion.
@@ -211,7 +211,7 @@ driver:
         # -- The image pull policy.
         pullPolicy: IfNotPresent
         # -- The image registry to pull from.
-        registry: gsoci.azurecr.io
+        registry: docker.io
         # -- The image repository to pull from.
         repository: falcosecurity/falco-driver-loader
         #  -- Overrides the image tag whose default is the chart appVersion.
@@ -346,7 +346,7 @@ falcoctl:
     # -- The image pull policy.
     pullPolicy: IfNotPresent
     # -- The image registry to pull from.
-    registry: gsoci.azurecr.io
+    registry: docker.io
     # -- The image repository to pull from.
     repository: falcosecurity/falcoctl
     # -- The image tag to pull.

--- a/helm/falco/charts/falcosidekick/values.yaml
+++ b/helm/falco/charts/falcosidekick/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 2
 
 image:
   # -- The image registry to pull from
-  registry: gsoci.azurecr.io
+  registry: docker.io
   # -- The image repository to pull from
   repository: falcosecurity/falcosidekick
   # -- The image tag to pull
@@ -965,7 +965,7 @@ webui:
   allowcors: false
   image:
     # -- The web UI image registry to pull from
-    registry: gsoci.azurecr.io
+    registry: docker.io
     # -- The web UI image repository to pull from
     repository: falcosecurity/falcosidekick-ui
     # -- The web UI image tag to pull
@@ -1049,7 +1049,7 @@ webui:
     enabled: true
     image:
       # -- The web UI Redis image registry to pull from
-      registry: gsoci.azurecr.io
+      registry: docker.io
       # -- The web UI Redis image repository to pull from
       repository: redis/redis-stack
       # -- The web UI Redis image tag to pull from

--- a/helm/falco/charts/falcosidekick/values.yaml
+++ b/helm/falco/charts/falcosidekick/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 2
 
 image:
   # -- The image registry to pull from
-  registry: docker.io
+  registry: gsoci.azurecr.io
   # -- The image repository to pull from
   repository: falcosecurity/falcosidekick
   # -- The image tag to pull
@@ -189,7 +189,8 @@ config:
     # -- default priority of dropped events, values are emergency|alert|critical|error|warning|notice|informational|debug
     dropeventdefaultpriority: "critical"
     # -- comma separated list of priority re-evaluation thresholds of dropped events composed of a ':' separated integer threshold and string priority. Example: `10000:critical, 100:warning, 1:informational`
-    dropeventthresholds: "10000:critical, 1000:critical, 100:critical, 10:warning, 1:warning"
+    dropeventthresholds: "10000:critical, 1000:critical, 100:critical, 10:warning,
+      1:warning"
     # -- if true, checkcert flag will be ignored (server cert will always be checked)
     mutualtls: false
     # -- check if ssl certificate of the output is valid
@@ -964,7 +965,7 @@ webui:
   allowcors: false
   image:
     # -- The web UI image registry to pull from
-    registry: docker.io
+    registry: gsoci.azurecr.io
     # -- The web UI image repository to pull from
     repository: falcosecurity/falcosidekick-ui
     # -- The web UI image tag to pull
@@ -1012,7 +1013,7 @@ webui:
     hosts:
       - host: falcosidekick-ui.local
         paths:
-        - path: /
+          - path: /
     # --  Web UI ingress TLS configuration
     tls: []
     #  - secretName: chart-example-tls
@@ -1048,7 +1049,7 @@ webui:
     enabled: true
     image:
       # -- The web UI Redis image registry to pull from
-      registry: docker.io
+      registry: gsoci.azurecr.io
       # -- The web UI Redis image repository to pull from
       repository: redis/redis-stack
       # -- The web UI Redis image tag to pull from

--- a/helm/falco/values.yaml
+++ b/helm/falco/values.yaml
@@ -14,7 +14,7 @@ kyvernoPolicyExceptions:
 
 falco:
   image:
-    registry: docker.io
+    registry: gsoci.azurecr.io
     repository: giantswarm/falco-no-driver
   priorityClassName: giantswarm-critical
   driver:
@@ -22,11 +22,11 @@ falco:
     loader:
       initContainer:
         image:
-          registry: docker.io
+          registry: gsoci.azurecr.io
           repository: giantswarm/falco-driver-loader
   tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
   # ebpf:
   #   enabled: true
   falco:
@@ -39,12 +39,12 @@ falco:
     name: "falco"
   falcoctl:
     image:
-      registry: docker.io
+      registry: gsoci.azurecr.io
       repository: giantswarm/falcoctl
 
 falco-exporter:
   image:
-    registry: docker.io
+    registry: gsoci.azurecr.io
     repository: giantswarm/falco-exporter
   podSecurityPolicy:
     create: true
@@ -57,10 +57,10 @@ falco-exporter:
       cpu: 100m
       memory: 128Mi
   tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
 
 falcosidekick:
   image:
-    registry: docker.io
+    registry: gsoci.azurecr.io
     repository: giantswarm/falcosidekick


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
