### PR TITLE
Enable CiliumNetworkPolicies by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable CiliumNetworkPolicies by default.
+
 ## [0.7.2] - 2024-01-12
 
 ### Changed

--- a/helm/falco/values.yaml
+++ b/helm/falco/values.yaml
@@ -1,5 +1,5 @@
 ciliumNetworkPolicy:
-  enabled: false
+  enabled: true
 
 global:
   podSecurityStandards:


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/29581

we should enable the policies by default - if no deny-all policies exist in the cluster then the policies will essentially have no effect (as the cluster network is already wide open).

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

**Important:** After this PR is tested and approved, ensure you "Squash and Merge" _unless you are updating a subtree_. The release automation in use on this repository relies on squashing, but git subtrees will be lost if squashed. This repo allows both, so you may need to change the merge type when merging.
