### PR TITLE
Add missing team label to service monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add missing team label to falco-exporter servicemonitor.
+
 ## [0.8.0] - 2024-01-25
 
 ### Changed

--- a/helm/falco/values.schema.json
+++ b/helm/falco/values.schema.json
@@ -174,6 +174,19 @@
                         }
                     }
                 },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "additionalLabels": {
+                            "type": "object",
+                            "properties": {
+                                "application.giantswarm.io/team": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
                 "tolerations": {
                     "type": "array",
                     "items": {

--- a/helm/falco/values.yaml
+++ b/helm/falco/values.yaml
@@ -56,6 +56,9 @@ falco-exporter:
     requests:
       cpu: 100m
       memory: 128Mi
+  serviceMonitor:
+    additionalLabels:
+      application.giantswarm.io/team: "shield"
   tolerations:
     - effect: NoSchedule
       key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
This PR adds the team label missing on the service monitor so the prometheus agent can pick up the service monitor otherwise falco is monitored by the MC prom

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.

**Important:** After this PR is tested and approved, ensure you "Squash and Merge" _unless you are updating a subtree_. The release automation in use on this repository relies on squashing, but git subtrees will be lost if squashed. This repo allows both, so you may need to change the merge type when merging.
