### PR TITLE
Update PolicyExceptions to v2beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove API check on PolicyException.
+
 ## [0.8.1] - 2024-04-30
 
 ### Changed

--- a/helm/falco/templates/falco-policy-exception.yaml
+++ b/helm/falco/templates/falco-policy-exception.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.kyvernoPolicyExceptions.enabled }}
   {{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" -}}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: {{ include "falco-helpers.fullname" . }}-falco-exceptions
@@ -50,7 +50,7 @@ spec:
         names:
         - {{ include "falco-helpers.fullname" . }}*
 ---
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: {{ include "falco-helpers.fullname" . }}-falco-exporter-exceptions
@@ -100,7 +100,7 @@ spec:
         names:
         - {{ include "falco-helpers.fullname" . }}-falco-exporter*
 ---
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: {{ include "falco-helpers.fullname" . }}-falcosidekick-exceptions

--- a/helm/falco/templates/falco-policy-exception.yaml
+++ b/helm/falco/templates/falco-policy-exception.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.kyvernoPolicyExceptions.enabled }}
-  {{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" -}}
 apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
@@ -138,5 +137,4 @@ spec:
         - {{ include "falco-helpers.namespace" . }}
         names:
         - {{ include "falco-helpers.fullname" . }}-falcosidekick*
-  {{- end -}}
 {{- end -}}


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.