### PR TITLE
Root CA key access rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add custom rule to detect access to root CA key file in control plane nodes
+
 ### Changed
 
 - Remove API check on PolicyException.

--- a/helm/falco/values.yaml
+++ b/helm/falco/values.yaml
@@ -24,6 +24,17 @@ falco:
         image:
           registry: gsoci.azurecr.io
           repository: giantswarm/falco-driver-loader
+  customRules:
+    gs-root-ca-key-access.yaml: |-
+      - list: root_ca_key_path
+        items: 
+        - "/etc/kubernetes/pki/ca.key"
+      - rule: File Related Operation on Root CA Key Path
+        desc: Detect any file operation on the path to root CA key
+        condition: (fs.path.name pmatch (root_ca_key_path) or fs.path.source pmatch (root_ca_key_path) or fs.path.target pmatch (root_ca_key_path))
+        output: "Some File Related Operation on root CA key (evt.type=%evt.type path=%fs.path.name source=%fs.path.source target=%fs.path.target user.name=%user.name proc.cmdline=%proc.cmdline proc.pcmdline=%proc.pcmdline container.id=%container.id container.name=%container.name image=%container.image.repository)"
+        priority: WARNING
+        source: syscall
   tolerations:
     - effect: NoSchedule
       key: node-role.kubernetes.io/control-plane
@@ -41,6 +52,7 @@ falco:
     image:
       registry: gsoci.azurecr.io
       repository: giantswarm/falcoctl
+  tty: true
 
 falco-exporter:
   image:


### PR DESCRIPTION
Added custom rule to detect access to the root CA key file in control plane nodes

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

**Important:** After this PR is tested and approved, ensure you "Squash and Merge" _unless you are updating a subtree_. The release automation in use on this repository relies on squashing, but git subtrees will be lost if squashed. This repo allows both, so you may need to change the merge type when merging.
