### PR TITLE
Inherit secrets to update-chart workflow

### DIFF
--- a/.github/workflows/update-from-fork.yaml
+++ b/.github/workflows/update-from-fork.yaml
@@ -35,5 +35,6 @@ jobs:
   call-update-chart:
     uses: ./.github/workflows/zz_generated.update_chart.yaml
     needs: sync-app-with-fork
+    secrets: inherit
     with:
       branch: 'main#update-chart'


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/31056

This PR allows to inherit the repository secrets to the update-chart workflow