### PR TITLE
chore: drop inline vendir customManager

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,17 +7,6 @@
   ],
   "packageRules": [
     {
-      "description": "Automerge architect updates",
-      "matchFileNames": [
-        ".circleci/config.yml"
-      ],
-      "matchDepNames": [
-        "architect"
-      ],
-      "groupName": "Architect",
-      "automerge": true
-    },
-    {
       "matchFileNames": ["vendir.yml"],
       "branchPrefix": "renovate/vendir/",
       "prCreation": "approval",

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,16 +5,6 @@
     "github>giantswarm/renovate-presets:disable-vendir.json5",
     "github>giantswarm/renovate-presets:disable-upstream-charts.json5"
   ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["(^|/)vendir\\.yml$"],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\n]+)\\n\\s+ref: (?<currentValue>[^\\n]+)"
-      ],
-      "versioningTemplate": "regex:^falco-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
-    }
-  ],
   "packageRules": [
     {
       "description": "Automerge architect updates",
@@ -32,7 +22,8 @@
       "branchPrefix": "renovate/vendir/",
       "prCreation": "approval",
       "groupName": "falco-upstream",
-      "separateMajorMinor": false
+      "separateMajorMinor": false,
+      "versioning": "regex:^falco-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
     }
   ]
 }


### PR DESCRIPTION
The vendir `customManager` and its matching `packageRule` (`branchPrefix`, `prCreation`) are now provided by `giantswarm/renovate-presets:default.json5` (renovate-presets#99). The inline copy is a duplicate once that PR lands.

The repo-specific `groupName`, `separateMajorMinor: false`, and the non-semver `versioning` override (`regex:^falco-\d+\.\d+\.\d+$`) are kept in the vendir `packageRule`. The versioning override moves from `versioningTemplate` on the customManager to `versioning` on the packageRule, which is the correct field for per-dep overrides in Renovate.

Merge after renovate-presets#99.