### PR TITLE
fix(chart): set daemonset maxUnavailable to 10%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bumped DaemonSet `updateStrategy.rollingUpdate.maxUnavailable` to `20%` so chart upgrades on larger management clusters can finish within the Flux HelmRelease timeout.
+- Bumped DaemonSet `updateStrategy.rollingUpdate.maxUnavailable` to `10%` so chart upgrades on larger management clusters can finish within the Flux HelmRelease timeout.
 
 ## [0.12.0] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped DaemonSet `updateStrategy.rollingUpdate.maxUnavailable` to `20%` so chart upgrades on larger management clusters can finish within the Flux HelmRelease timeout.
+
 ## [0.12.0] - 2026-06-08
 
 ### Changed

--- a/helm/falco/values.yaml
+++ b/helm/falco/values.yaml
@@ -43,6 +43,10 @@ falco:
   # ebpf:
   #   enabled: true
   controller:
+    daemonset:
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 20%
     labels:
       application.giantswarm.io/team: "shield"
 

--- a/helm/falco/values.yaml
+++ b/helm/falco/values.yaml
@@ -46,7 +46,7 @@ falco:
     daemonset:
       updateStrategy:
         rollingUpdate:
-          maxUnavailable: 20%
+          maxUnavailable: 10%
     labels:
       application.giantswarm.io/team: "shield"
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/36817

- The chart-upstream default for `controller.daemonset.updateStrategy.rollingUpdate.maxUnavailable` is `1`, which forces a sequential rollout. On larger Giant Swarm MCs, the falco DaemonSet rollout can exceed the Flux HelmRelease timeout and auto-rollback.
- Sets the default to `10%` so up to one-in-five nodes upgrade in parallel.
